### PR TITLE
feature: Added a workflow to deploy the MKDocs site to GitHub pages

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,43 @@
+name: Deploy MkDocs site
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy-pages.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: pip install mkdocs mkdocs-material
+
+      - name: Build site
+        run: mkdocs build -d site
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+      - name: Deploy to GitHub Pages
+        id: deploy-pages
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
# 🧠 GROW Notebook Contribution or Question

Thanks for contributing to your student notebook or reaching out with a question!

Please complete the relevant section(s) below.

---

## 📝 Suggested PR Title

> Format your PR title like one of the following:
> - `lab: add nginx pod with securityContext`
> - `reflection: week2 submission`
> - `question: FluxCD error in apply`

---

## ✍️ What is this PR for?

- [ ] I’m updating or adding new lab work
- [ ] I’m submitting a reflection or weekly journal
- [ ] I have a question for a KubeSkills instructor
- [x] I'm proposing a new feature to the project

---

## 📝 Description

This is a proposal to add a GitHub Actions workflow that will deploy the MKDocs site to GitHub Pages.

From my experience, when GitHub Pages is enabled for the repo, and the **Deploy from a branch** is chosen under **Build and Deployment**, not all features of the Material theme are rendered.

When choosing **GitHub Actions** as **Source**, this workflow is triggered, and the MKDocs and Material packages are installed. This will allow the page to be displayed correctly, according to the settings defined in the `mkdocs.yml`.
